### PR TITLE
Fix visitors list subscription order

### DIFF
--- a/react/features/visitors/websocket-client.ts
+++ b/react/features/visitors/websocket-client.ts
@@ -198,27 +198,40 @@ export class WebsocketClient {
             logger.debug('Connected to visitors list websocket');
             connectCallback?.();
 
-            // First subscribe to queue for initial list
-            const queueSubscription = this.stompClient.subscribe(queueEndpoint, message => {
+            let initialReceived = false;
+            let queueSubscription: any;
+            const cachedDeltas: Array<{ n: string; r: string; s: string; }> = [];
+
+            // Subscribe first for deltas so we don't miss any while waiting for the initial list
+            this.stompClient.subscribe(topicEndpoint, deltaMessage => {
+                try {
+                    const updates: Array<{ n: string; r: string; s: string; }> = JSON.parse(deltaMessage.body);
+
+                    if (!initialReceived) {
+                        cachedDeltas.push(...updates);
+                    } else {
+                        deltaCallback(updates);
+                    }
+                } catch (e) {
+                    logger.error(`Error parsing visitors delta response: ${deltaMessage}`, e);
+                }
+            });
+
+            // Subscribe for the initial list after topic subscription is active
+            queueSubscription = this.stompClient.subscribe(queueEndpoint, message => {
                 try {
                     const visitors: Array<{ n: string; r: string; }> = JSON.parse(message.body);
 
                     logger.debug(`Received initial visitors list with ${visitors.length} visitors`);
+                    initialReceived = true;
                     initialCallback(visitors);
 
-                    // Unsubscribe from queue and subscribe to topic for deltas
                     queueSubscription.unsubscribe();
-                    this.stompClient?.subscribe(topicEndpoint, deltaMessage => {
-                        try {
-                            const updates: Array<{ n: string; r: string; s: string; }> = JSON.parse(deltaMessage.body);
 
-                            deltaCallback(updates);
-
-                        } catch (e) {
-                            logger.error(`Error parsing visitors delta response: ${deltaMessage}`, e);
-                        }
-                    });
-
+                    if (cachedDeltas.length) {
+                        deltaCallback(cachedDeltas);
+                        cachedDeltas.length = 0;
+                    }
                 } catch (e) {
                     logger.error(`Error parsing initial visitors response: ${message}`, e);
                 }


### PR DESCRIPTION
## Summary
- subscribe to the visitors list topic before queue
- cache deltas until the initial list is received

## Testing
- `npm run tsc:ci`
- `npm run lint:ci`
- `npm start` *(fails: ENOSPC watch limit)*
- `npm run test-dev-single Visitors` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_686697b61300832581a734eaa3ce0c11